### PR TITLE
Introduce cassandra.skip-partition-check

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
@@ -66,6 +66,7 @@ public class CassandraClientConfig
     private Duration noHostAvailableRetryTimeout = new Duration(1, MINUTES);
     private int speculativeExecutionLimit = 1;
     private Duration speculativeExecutionDelay = new Duration(500, MILLISECONDS);
+    private boolean skipPartitionCheck;
 
     @NotNull
     @Size(min = 1)
@@ -377,6 +378,18 @@ public class CassandraClientConfig
     public CassandraClientConfig setSpeculativeExecutionDelay(Duration speculativeExecutionDelay)
     {
         this.speculativeExecutionDelay = speculativeExecutionDelay;
+        return this;
+    }
+
+    public boolean isSkipPartitionCheck()
+    {
+        return skipPartitionCheck;
+    }
+
+    @Config("cassandra.skip-partition-check")
+    public CassandraClientConfig setSkipPartitionCheck(boolean skipPartitionCheck)
+    {
+        this.skipPartitionCheck = skipPartitionCheck;
         return this;
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -148,6 +148,7 @@ public class CassandraClientModule
                     contactPoints.forEach(clusterBuilder::addContactPoint);
                     return clusterBuilder.build();
                 }),
-                config.getNoHostAvailableRetryTimeout());
+                config.getNoHostAvailableRetryTimeout(),
+                config.isSkipPartitionCheck());
     }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -331,6 +331,22 @@ public enum CassandraType
         }
     }
 
+    public static String getColumnValueForCql(Object object, CassandraType cassandraType)
+    {
+        switch (cassandraType) {
+            case ASCII:
+            case TEXT:
+            case VARCHAR:
+                return CassandraCqlUtils.quoteStringLiteral(((Slice) object).toStringUtf8());
+            case INT:
+            case BIGINT:
+                return object.toString();
+            default:
+                throw new IllegalStateException("Handling of type " + cassandraType
+                        + " is not implemented");
+        }
+    }
+
     private static String objectToString(Object object, CassandraType elemType)
     {
         switch (elemType) {

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/NativeCassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/NativeCassandraSession.java
@@ -52,6 +52,7 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
 import io.airlift.units.Duration;
 
 import java.nio.ByteBuffer;
@@ -76,6 +77,7 @@ import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static java.util.Locale.ENGLISH;
@@ -98,13 +100,15 @@ public class NativeCassandraSession
     private final Cluster cluster;
     private final Supplier<Session> session;
     private final Duration noHostAvailableRetryTimeout;
+    private final boolean skipPartitionCheck;
 
-    public NativeCassandraSession(String connectorId, JsonCodec<List<ExtraColumnMetadata>> extraColumnMetadataCodec, Cluster cluster, Duration noHostAvailableRetryTimeout)
+    public NativeCassandraSession(String connectorId, JsonCodec<List<ExtraColumnMetadata>> extraColumnMetadataCodec, Cluster cluster, Duration noHostAvailableRetryTimeout, boolean skipPartitionCheck)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.extraColumnMetadataCodec = requireNonNull(extraColumnMetadataCodec, "extraColumnMetadataCodec is null");
         this.cluster = requireNonNull(cluster, "cluster is null");
         this.noHostAvailableRetryTimeout = requireNonNull(noHostAvailableRetryTimeout, "noHostAvailableRetryTimeout is null");
+        this.skipPartitionCheck = skipPartitionCheck;
         this.session = memoize(cluster::connect);
     }
 
@@ -353,6 +357,10 @@ public class NativeCassandraSession
     @Override
     public List<CassandraPartition> getPartitions(CassandraTable table, List<Set<Object>> filterPrefixes)
     {
+        if (skipPartitionCheck) {
+            return buildPartitionsFromFilterPrefixes(table, filterPrefixes);
+        }
+
         List<CassandraColumnHandle> partitionKeyColumns = table.getPartitionKeyColumns();
 
         if (filterPrefixes.size() != partitionKeyColumns.size()) {
@@ -407,6 +415,88 @@ public class NativeCassandraSession
                 stringBuilder.append(CassandraCqlUtils.validColumnName(columnHandle.getName()));
                 stringBuilder.append(" = ");
                 stringBuilder.append(CassandraType.getColumnValueForCql(row, i, columnHandle.getCassandraType()));
+            }
+            buffer.flip();
+            byte[] key = new byte[buffer.limit()];
+            buffer.get(key);
+            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.fromFixedValues(map);
+            String partitionId = stringBuilder.toString();
+            if (uniquePartitionIds.add(partitionId)) {
+                partitions.add(new CassandraPartition(key, partitionId, tupleDomain, false));
+            }
+        }
+        return partitions.build();
+    }
+
+    private List<CassandraPartition> buildPartitionsFromFilterPrefixes(CassandraTable table, List<Set<Object>> filterPrefixes)
+    {
+        List<CassandraColumnHandle> partitionKeyColumns = table.getPartitionKeyColumns();
+
+        if (filterPrefixes.size() != partitionKeyColumns.size()) {
+            return ImmutableList.of(CassandraPartition.UNPARTITIONED);
+        }
+
+        ByteBuffer buffer = ByteBuffer.allocate(1000);
+        HashMap<ColumnHandle, NullableValue> map = new HashMap<>();
+        Set<String> uniquePartitionIds = new HashSet<>();
+        StringBuilder stringBuilder = new StringBuilder();
+
+        boolean isComposite = partitionKeyColumns.size() > 1;
+
+        ImmutableList.Builder<CassandraPartition> partitions = ImmutableList.builder();
+        for (List<Object> values : Sets.cartesianProduct(filterPrefixes)) {
+            buffer.clear();
+            map.clear();
+            stringBuilder.setLength(0);
+            for (int i = 0; i < partitionKeyColumns.size(); i++) {
+                Object value = values.get(i);
+                CassandraColumnHandle columnHandle = partitionKeyColumns.get(i);
+                CassandraType cassandraType = columnHandle.getCassandraType();
+
+                switch (cassandraType) {
+                    case TEXT:
+                        Slice slice = (Slice) value;
+                        if (isComposite) {
+                            buffer.putShort((short) slice.length());
+                            buffer.put(slice.getBytes());
+                            buffer.put((byte) 0);
+                        }
+                        else {
+                            buffer.put(slice.getBytes());
+                        }
+                        break;
+                    case INT:
+                        int intValue = toIntExact((long) value);
+                        if (isComposite) {
+                            buffer.putShort((short) Integer.BYTES);
+                            buffer.putInt(intValue);
+                            buffer.put((byte) 0);
+                        }
+                        else {
+                            buffer.putInt(intValue);
+                        }
+                        break;
+                    case BIGINT:
+                        if (isComposite) {
+                            buffer.putShort((short) Long.BYTES);
+                            buffer.putLong((long) value);
+                            buffer.put((byte) 0);
+                        }
+                        else {
+                            buffer.putLong((long) value);
+                        }
+                        break;
+                    default:
+                        throw new IllegalStateException("Handling of type " + cassandraType + " is not implemented");
+                }
+
+                map.put(columnHandle, NullableValue.of(cassandraType.getNativeType(), value));
+                if (i > 0) {
+                    stringBuilder.append(" AND ");
+                }
+                stringBuilder.append(CassandraCqlUtils.validColumnName(columnHandle.getName()));
+                stringBuilder.append(" = ");
+                stringBuilder.append(CassandraType.getColumnValueForCql(value, cassandraType));
             }
             buffer.flip();
             byte[] key = new byte[buffer.limit()];

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/NativeCassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/NativeCassandraSession.java
@@ -454,7 +454,9 @@ public class NativeCassandraSession
                 CassandraType cassandraType = columnHandle.getCassandraType();
 
                 switch (cassandraType) {
+                    case ASCII:
                     case TEXT:
+                    case VARCHAR:
                         Slice slice = (Slice) value;
                         if (isComposite) {
                             buffer.putShort((short) slice.length());

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/EmbeddedCassandra.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/EmbeddedCassandra.java
@@ -57,6 +57,7 @@ public final class EmbeddedCassandra
     private static final Duration REFRESH_SIZE_ESTIMATES_TIMEOUT = new Duration(1, MINUTES);
 
     private static CassandraSession session;
+    private static ReopeningCluster cluster;
     private static boolean initialized;
 
     private EmbeddedCassandra() {}
@@ -89,7 +90,8 @@ public final class EmbeddedCassandra
                 "EmbeddedCassandra",
                 JsonCodec.listJsonCodec(ExtraColumnMetadata.class),
                 cluster,
-                new Duration(1, MINUTES));
+                new Duration(1, MINUTES),
+                false);
 
         try {
             checkConnectivity(session);
@@ -101,6 +103,7 @@ public final class EmbeddedCassandra
         }
 
         EmbeddedCassandra.session = session;
+        EmbeddedCassandra.cluster = cluster;
         initialized = true;
     }
 
@@ -139,6 +142,12 @@ public final class EmbeddedCassandra
     {
         checkIsInitialized();
         return PORT;
+    }
+
+    public static synchronized ReopeningCluster getCluster()
+    {
+        checkIsInitialized();
+        return cluster;
     }
 
     private static void checkIsInitialized()

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
@@ -55,7 +55,8 @@ public class TestCassandraClientConfig
                 .setWhiteListAddresses("")
                 .setNoHostAvailableRetryTimeout(new Duration(1, MINUTES))
                 .setSpeculativeExecutionLimit(1)
-                .setSpeculativeExecutionDelay(new Duration(500, MILLISECONDS)));
+                .setSpeculativeExecutionDelay(new Duration(500, MILLISECONDS))
+                .setSkipPartitionCheck(false));
     }
 
     @Test
@@ -86,6 +87,7 @@ public class TestCassandraClientConfig
                 .put("cassandra.no-host-available-retry-timeout", "3m")
                 .put("cassandra.speculative-execution.limit", "10")
                 .put("cassandra.speculative-execution.delay", "101s")
+                .put("cassandra.skip-partition-check", "true")
                 .build();
 
         CassandraClientConfig expected = new CassandraClientConfig()
@@ -112,7 +114,8 @@ public class TestCassandraClientConfig
                 .setWhiteListAddresses("host1")
                 .setNoHostAvailableRetryTimeout(new Duration(3, MINUTES))
                 .setSpeculativeExecutionLimit(10)
-                .setSpeculativeExecutionDelay(new Duration(101, SECONDS));
+                .setSpeculativeExecutionDelay(new Duration(101, SECONDS))
+                .setSkipPartitionCheck(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestNativeCassandraSession.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestNativeCassandraSession.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cassandra;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slices;
+import io.airlift.units.Duration;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.cassandra.CassandraTestingUtils.createKeyspace;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestNativeCassandraSession
+{
+    private static final String KEYSPACE = "test_native_cassandra_session_keyspace";
+    private static final int FILTER_PARTITION_COUNT = 5;
+    private static final int EXISTING_PARTITION_COUNT = 4;
+    private static final int CLUSTERING_KEY_COUNT = 3;
+
+    private CassandraSession session;
+
+    @BeforeClass
+    public void setUp() throws Exception
+    {
+        EmbeddedCassandra.start();
+        session = EmbeddedCassandra.getSession();
+        createKeyspace(session, KEYSPACE);
+    }
+
+    @Test
+    public void testGetPartitionsFromSingleParitionKeyTable()
+    {
+        NativeCassandraSession nativeSession = buildNativeSession(false);
+        String tableName = "single_part_key_table";
+        CassandraTable table = createSinglePartitionKeyTable(tableName);
+
+        ImmutableList<Set<Object>> partitionKeysList = buildSinglePartitionKeysList();
+        List<CassandraPartition> partitions = nativeSession.getPartitions(table, partitionKeysList);
+
+        assertEquals(partitions.size(), EXISTING_PARTITION_COUNT);
+        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+    }
+
+    @Test
+    public void testGetPartitionsFromSinglePartitionKeyTableWithSkipPartitionCheck()
+    {
+        NativeCassandraSession nativeSession = buildNativeSession(true);
+        String tableName = "single_part_key_with_skip_partition_check_table";
+        CassandraTable table = createSinglePartitionKeyTable(tableName);
+
+        ImmutableList<Set<Object>> partitionKeysList = buildSinglePartitionKeysList();
+        List<CassandraPartition> partitions = nativeSession.getPartitions(table, partitionKeysList);
+
+        assertEquals(partitions.size(), FILTER_PARTITION_COUNT);
+        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+    }
+
+    @Test
+    public void testGetPartitionsFromMultipleParitionKeyTable()
+    {
+        NativeCassandraSession nativeSession = buildNativeSession(false);
+        String tableName = "multi_part_key_table";
+        CassandraTable table = createMultiplePartitionKeyTable(tableName);
+
+        ImmutableList<Set<Object>> partitionKeysList = buildMultiplePartitionKeysList();
+        List<CassandraPartition> partitions = nativeSession.getPartitions(table, partitionKeysList);
+
+        assertEquals(partitions.size(), EXISTING_PARTITION_COUNT);
+        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+    }
+
+    @Test
+    public void testGetPartitionsFromMultiplePartitionKeyTableWithSkipPartitionCheck()
+    {
+        NativeCassandraSession nativeSession = buildNativeSession(true);
+        String tableName = "multi_part_key_with_skip_partition_check_table";
+        CassandraTable table = createMultiplePartitionKeyTable(tableName);
+
+        ImmutableList<Set<Object>> partitionKeysList = buildMultiplePartitionKeysList();
+        List<CassandraPartition> partitions = nativeSession.getPartitions(table, partitionKeysList);
+
+        assertEquals(partitions.size(), FILTER_PARTITION_COUNT * FILTER_PARTITION_COUNT);
+        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+    }
+
+    private NativeCassandraSession buildNativeSession(boolean skipPartitionCheck)
+    {
+        return new NativeCassandraSession(
+                "TestNativeCassandraSession",
+                JsonCodec.listJsonCodec(ExtraColumnMetadata.class),
+                EmbeddedCassandra.getCluster(),
+                new Duration(1, MINUTES),
+                skipPartitionCheck);
+    }
+
+    private ImmutableList<Set<Object>> buildSinglePartitionKeysList()
+    {
+        ImmutableSet.Builder<Object> partitionColumnValues = ImmutableSet.builder();
+        for (int i = 0; i < FILTER_PARTITION_COUNT; i++) {
+            partitionColumnValues.add((long) i);
+        }
+        return ImmutableList.of(partitionColumnValues.build());
+    }
+
+    private CassandraTable createSinglePartitionKeyTable(String tableName)
+    {
+        session.execute(format("CREATE TABLE %s.%s (partition_key1 bigint, clustering_key1 bigint, PRIMARY KEY (partition_key1, clustering_key1))", KEYSPACE, tableName));
+        for (int i = 0; i < EXISTING_PARTITION_COUNT; i++) {
+            for (int j = 0; j < CLUSTERING_KEY_COUNT; j++) {
+                session.execute(format("INSERT INTO %s.%s (partition_key1, clustering_key1) VALUES (%d, %d)", KEYSPACE, tableName, i, j));
+            }
+        }
+
+        CassandraColumnHandle col1 = new CassandraColumnHandle("cassandra", "partition_key1", 1, CassandraType.BIGINT, null, true, false, false, false);
+        CassandraColumnHandle col2 = new CassandraColumnHandle("cassandra", "clustering_key1", 2, CassandraType.BIGINT, null, false, true, false, false);
+        return new CassandraTable(new CassandraTableHandle("cassandra", KEYSPACE, tableName), ImmutableList.of(col1, col2));
+    }
+
+    private ImmutableList<Set<Object>> buildMultiplePartitionKeysList()
+    {
+        ImmutableSet.Builder<Object> col1Values = ImmutableSet.builder();
+        ImmutableSet.Builder<Object> col2Values = ImmutableSet.builder();
+        for (int i = 0; i < FILTER_PARTITION_COUNT; i++) {
+            col1Values.add((long) i);
+            col2Values.add(Slices.utf8Slice(Integer.toString(i)));
+        }
+        return ImmutableList.of(col1Values.build(), col2Values.build());
+    }
+
+    private CassandraTable createMultiplePartitionKeyTable(String tableName)
+    {
+        session.execute(format("CREATE TABLE %s.%s (partition_key1 bigint, partition_key2 text, clustering_key1 bigint, PRIMARY KEY ((partition_key1, partition_key2), clustering_key1))", KEYSPACE, tableName));
+        for (int i = 0; i < EXISTING_PARTITION_COUNT; i++) {
+            for (int j = 0; j < CLUSTERING_KEY_COUNT; j++) {
+                session.execute(format("INSERT INTO %s.%s (partition_key1, partition_key2, clustering_key1) VALUES (%d, '%s', %d)", KEYSPACE, tableName, i, Integer.toString(i), j));
+            }
+        }
+
+        CassandraColumnHandle col1 = new CassandraColumnHandle("cassandra", "partition_key1", 1, CassandraType.BIGINT, null, true, false, false, false);
+        CassandraColumnHandle col2 = new CassandraColumnHandle("cassandra", "partition_key2", 2, CassandraType.TEXT, null, true, false, false, false);
+        CassandraColumnHandle col3 = new CassandraColumnHandle("cassandra", "clustering_key1", 3, CassandraType.BIGINT, null, false, true, false, false);
+        return new CassandraTable(new CassandraTableHandle("cassandra", KEYSPACE, tableName), ImmutableList.of(col1, col2, col3));
+    }
+}

--- a/presto-main/etc/catalog/cassandra.properties
+++ b/presto-main/etc/catalog/cassandra.properties
@@ -1,0 +1,2 @@
+connector.name=cassandra
+cassandra.contact-points=localhost

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -28,6 +28,7 @@ query.min-expire-age=30m
 
 plugin.bundles=\
   ../presto-blackhole/pom.xml,\
+  ../presto-cassandra/pom.xml, \
   ../presto-memory/pom.xml,\
   ../presto-jmx/pom.xml,\
   ../presto-raptor/pom.xml,\


### PR DESCRIPTION
`NativeCassandraSession#getPartitions` is very slow if there are many partitions used in WHERE clause.
In our use, the partitions usually exist, so skipping partition check will reduce planning time and wall time.

In my experiment, "cassandra.skip-partition-check" reduced analysis time of a certain query from 22829 msec to 1060 msec.