### PR TITLE
Implement predicate pushdown of kafka-connector with partition_id, parrtition_offset

### DIFF
--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
@@ -204,7 +204,7 @@ public class KafkaMetadata
     public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
     {
         KafkaTableHandle handle = convertTableHandle(table);
-        ConnectorTableLayout layout = new ConnectorTableLayout(new KafkaTableLayoutHandle(handle));
+        ConnectorTableLayout layout = new ConnectorTableLayout(new KafkaTableLayoutHandle(handle, constraint.getSummary()));
         return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
     }
 

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplitManager.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplitManager.java
@@ -150,14 +150,9 @@ public class KafkaSplitManager
                         ArrayList<Range> intersectedRanges = new ArrayList<>();
                         for (Range range : partitionOffsetDomain.getValues().getRanges().getOrderedRanges()) {
                             for (Range offsetRange : offsetRanges) {
-                                if (range.getLow().compareTo(offsetRange.getHigh()) > 0) {
-                                    continue;
+                                if (range.overlaps(offsetRange)) {
+                                    intersectedRanges.add(range.intersect(offsetRange));
                                 }
-                                if (range.getHigh().compareTo(offsetRange.getLow()) < 0) {
-                                    continue;
-                                }
-
-                                intersectedRanges.add(range.intersect(offsetRange));
                             }
                         }
                         offsetRanges = intersectedRanges;

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableLayoutHandle.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableLayoutHandle.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.kafka;
 
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -23,17 +25,27 @@ public class KafkaTableLayoutHandle
         implements ConnectorTableLayoutHandle
 {
     private final KafkaTableHandle table;
+    private final TupleDomain<ColumnHandle> tupleDomain;
 
     @JsonCreator
-    public KafkaTableLayoutHandle(@JsonProperty("table") KafkaTableHandle table)
+    public KafkaTableLayoutHandle(
+            @JsonProperty("table") KafkaTableHandle table,
+            @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> domain)
     {
         this.table = requireNonNull(table, "table is null");
+        this.tupleDomain = requireNonNull(domain, "table is null");
     }
 
     @JsonProperty
     public KafkaTableHandle getTable()
     {
         return table;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getTupleDomain()
+    {
+        return tupleDomain;
     }
 
     @Override

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/KafkaQueryRunner.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/KafkaQueryRunner.java
@@ -59,6 +59,12 @@ public final class KafkaQueryRunner
     public static DistributedQueryRunner createKafkaQueryRunner(EmbeddedKafka embeddedKafka, Iterable<TpchTable<?>> tables)
             throws Exception
     {
+        return createKafkaQueryRunner(embeddedKafka, tables, true);
+    }
+
+    public static DistributedQueryRunner createKafkaQueryRunner(EmbeddedKafka embeddedKafka, Iterable<TpchTable<?>> tables, boolean hideInternalColumns)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = null;
         try {
             queryRunner = new DistributedQueryRunner(createSession(), 2);
@@ -74,7 +80,7 @@ public final class KafkaQueryRunner
 
             Map<SchemaTableName, KafkaTopicDescription> topicDescriptions = createTpchTopicDescriptions(queryRunner.getCoordinator().getMetadata(), tables);
 
-            installKafkaPlugin(embeddedKafka, queryRunner, topicDescriptions);
+            installKafkaPlugin(embeddedKafka, queryRunner, topicDescriptions, hideInternalColumns);
 
             TestingPrestoClient prestoClient = queryRunner.getClient();
 

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTestWithInternalColumns.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTestWithInternalColumns.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.kafka.util.EmbeddedKafka;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.facebook.presto.kafka.KafkaQueryRunner.createKafkaQueryRunner;
+import static com.facebook.presto.kafka.util.EmbeddedKafka.createEmbeddedKafka;
+import static io.airlift.tpch.TpchTable.ORDERS;
+
+@Test
+public class TestKafkaIntegrationSmokeTestWithInternalColumns
+        extends AbstractTestQueryFramework
+{
+    private final EmbeddedKafka embeddedKafka;
+
+    public TestKafkaIntegrationSmokeTestWithInternalColumns()
+            throws Exception
+    {
+        this(createEmbeddedKafka());
+    }
+
+    public TestKafkaIntegrationSmokeTestWithInternalColumns(EmbeddedKafka embeddedKafka)
+    {
+        super(() -> createKafkaQueryRunner(embeddedKafka, ImmutableList.of(ORDERS), false));
+        this.embeddedKafka = embeddedKafka;
+    }
+
+    @Test
+    public void testPartitionIdPredicate()
+    {
+        assertQuery(
+                "SELECT _partition_id, min(_partition_offset), max(_partition_offset) FROM orders WHERE _partition_id BETWEEN 0 AND 1 AND _partition_offset >= 100 AND _partition_offset <= 1000 GROUP BY _partition_id ORDER BY _partition_id ",
+                "VALUES (0, 100, 1000), (1, 100, 1000)");
+    }
+
+    @Test
+    public void testPartitionOffsetPredicate()
+    {
+        assertQuery(
+                "SELECT _partition_id, min(_partition_offset), max(_partition_offset) FROM orders WHERE _partition_offset >= 10 AND _partition_offset < 7500 GROUP BY _partition_id",
+                "VALUES (0, 10, 7499), (1, 10, 7499)");
+        assertQuery(
+                "SELECT _partition_id, min(_partition_offset), max(_partition_offset) FROM orders WHERE _partition_offset BETWEEN 100 AND 1000 GROUP BY _partition_id",
+                "VALUES (0, 100, 1000), (1, 100, 1000)");
+        assertQuery(
+                "SELECT _partition_id, min(_partition_offset), max(_partition_offset) FROM orders WHERE _partition_id = 1 AND _partition_offset BETWEEN 100 AND 1000 GROUP BY _partition_id",
+                "VALUES (1, 100, 1000)");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+            throws IOException
+    {
+        embeddedKafka.close();
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTestWithInternalColumns.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTestWithInternalColumns.java
@@ -47,7 +47,10 @@ public class TestKafkaIntegrationSmokeTestWithInternalColumns
     public void testPartitionIdPredicate()
     {
         assertQuery(
-                "SELECT _partition_id, min(_partition_offset), max(_partition_offset) FROM orders WHERE _partition_id BETWEEN 0 AND 1 AND _partition_offset >= 100 AND _partition_offset <= 1000 GROUP BY _partition_id ORDER BY _partition_id ",
+                "SELECT _partition_id, min(_partition_offset), max(_partition_offset) FROM orders WHERE _partition_id = 1 GROUP BY _partition_id",
+                "VALUES (1, 0, 7499)");
+        assertQuery(
+                "SELECT _partition_id, min(_partition_offset), max(_partition_offset) FROM orders WHERE _partition_id BETWEEN 0 AND 1 AND _partition_offset >= 100 AND _partition_offset <= 1000 GROUP BY _partition_id",
                 "VALUES (0, 100, 1000), (1, 100, 1000)");
     }
 
@@ -63,6 +66,9 @@ public class TestKafkaIntegrationSmokeTestWithInternalColumns
         assertQuery(
                 "SELECT _partition_id, min(_partition_offset), max(_partition_offset) FROM orders WHERE _partition_id = 1 AND _partition_offset BETWEEN 100 AND 1000 GROUP BY _partition_id",
                 "VALUES (1, 100, 1000)");
+        assertQuery(
+                "SELECT _partition_id, _partition_offset FROM orders WHERE (_partition_offset >= 100 AND _partition_offset < 102) OR (_partition_id = 1 AND _partition_offset > 7498) OR (_partition_offset BETWEEN 200 AND 201)",
+                "VALUES (0, 100), (1, 100), (0, 101), (1, 101), (0, 200), (1, 200), (0, 201), (1, 201), (1, 7499)");
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/TestUtils.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/TestUtils.java
@@ -57,6 +57,11 @@ public final class TestUtils
 
     public static void installKafkaPlugin(EmbeddedKafka embeddedKafka, QueryRunner queryRunner, Map<SchemaTableName, KafkaTopicDescription> topicDescriptions)
     {
+        installKafkaPlugin(embeddedKafka, queryRunner, topicDescriptions, true);
+    }
+
+    public static void installKafkaPlugin(EmbeddedKafka embeddedKafka, QueryRunner queryRunner, Map<SchemaTableName, KafkaTopicDescription> topicDescriptions, boolean hideInternalColumns)
+    {
         KafkaPlugin kafkaPlugin = new KafkaPlugin();
         kafkaPlugin.setTableDescriptionSupplier(() -> topicDescriptions);
         queryRunner.installPlugin(kafkaPlugin);
@@ -65,6 +70,7 @@ public final class TestUtils
                 "kafka.nodes", embeddedKafka.getConnectString(),
                 "kafka.table-names", Joiner.on(",").join(topicDescriptions.keySet()),
                 "kafka.connect-timeout", "120s",
+                "kafka.hide-internal-columns", hideInternalColumns ? "true" : "false",
                 "kafka.default-schema", "default");
         queryRunner.createCatalog("kafka", "kafka", kafkaConfig);
     }


### PR DESCRIPTION
kafka can fetch records from particular partitions and particular offset ranges.
This patch enable to limit ranges of fetch target when presto gathers splits.